### PR TITLE
oval button refactored

### DIFF
--- a/src/components/oval_button.js
+++ b/src/components/oval_button.js
@@ -1,5 +1,4 @@
 import React from "react"
-import arrow_rt from "../images/icons/arrow-right.svg"
 import styles from "./oval_button.module.scss"
 import { Link } from "gatsby"
 

--- a/src/components/oval_button.js
+++ b/src/components/oval_button.js
@@ -1,0 +1,36 @@
+import React from "react"
+import arrow_rt from "../images/icons/arrow-right.svg"
+import styles from "./oval_button.module.scss"
+import { Link } from "gatsby"
+
+function OvalButton(props) {
+  let link = ""
+  if (props.external) {
+    link = (
+      <a
+        className={styles.link}
+        href={props.to}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {props.text}
+      </a>
+    )
+  } else {
+    link = (
+      <Link className={styles.link} to={props.to}>
+        {props.text}
+      </Link>
+    )
+  }
+  return (
+    <div className={styles.btn}>
+      {link}
+      <div className={styles.arrow}>
+        <i class="fas fa-arrow-right fa-2x"></i>
+      </div>
+    </div>
+  )
+}
+
+export default OvalButton

--- a/src/components/oval_button.module.scss
+++ b/src/components/oval_button.module.scss
@@ -1,0 +1,34 @@
+/*OVAL BUTTON SPECIFIC CSS*/
+@import "../pages/styles";
+
+.btn {
+  display: flex;
+  border: 3px solid white;
+  border-radius: 20px;
+  color: white;
+  width: auto;
+  max-width: 300px;
+  white-space: nowrap;
+  background-color: $green;
+  margin: 15px 50px;
+  justify-content: flex-start;
+  overflow: hidden;
+}
+
+.link {
+  background-color: $red;
+  color: $tan;
+  font-size: 2.5em;
+  padding: 0 10px;
+  flex: 4 0;
+  text-align: center;
+  height: 100%;
+}
+
+.arrow {
+  display: flex;
+  flex: 1 0;
+  padding: 0 10px;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/images/icons/arrow-right.svg
+++ b/src/images/icons/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="39" height="32" viewBox="0 0 39 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.58667 16.0667H34.7333M34.7333 16.0667L23.0533 4.38672M34.7333 16.0667L23.0533 27.7467" stroke="white" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,6 @@ import React from "react"
 import "./styles.scss"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import { Link } from "gatsby"
 import hqico from "../images/sponsors/hqgso.jpg"
 import allegacyico from "../images/sponsors/allegacy.jpg"
 import ibmico from "../images/sponsors/ibmico.jpg"
@@ -53,7 +52,7 @@ const IndexPage = () => (
             something else to contribute, we’d love to have you come along with
             us on this journey.{" "}
           </p>
-          <OvalButton to="/join" text="Join Us" />
+          <OvalButton type="internal" to="/join" text="Join Us" />
         </div>
         <div className="column is-one-fifth is-hidden-mobile">
           <figure className="image is-square">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ import slackico from "../images/social/slack_icon.svg"
 import githubico from "../images/social/github_icon.svg"
 import meetupico from "../images/social/meetup_icon.svg"
 import { Helmet } from "react-helmet"
-
+import OvalButton from "../components/oval_button"
 const IndexPage = () => (
   <Layout>
     <SEO title="Code for Greensboro - Local Code for America Brigade" />
@@ -53,14 +53,7 @@ const IndexPage = () => (
             something else to contribute, we’d love to have you come along with
             us on this journey.{" "}
           </p>
-          <div className="join-button">
-            <Link className="join-button-link" to="/join">
-              Join Us
-            </Link>
-            <div className="btn-arrow">
-              <i class="fas fa-arrow-right fa-2x"></i>
-            </div>
-          </div>
+          <OvalButton to="/join" text="Join Us" />
         </div>
         <div className="column is-one-fifth is-hidden-mobile">
           <figure className="image is-square">
@@ -101,51 +94,27 @@ const IndexPage = () => (
         <div className="columns">
           <div className="column">
             <img src={slackico} alt="Slack Logo" />
-            <div className="join-button">
-              <a
-                className="join-button-link"
-                href="https://bit.ly/cfgso-slack"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Join Us
-              </a>
-              <div className="btn-arrow">
-                <i class="fas fa-arrow-right fa-2x"></i>
-              </div>
-            </div>
+            <OvalButton
+              text="Join Us"
+              to="https://bit.ly/cfgso-slack"
+              external="true"
+            />
           </div>
           <div className="column">
             <img src={githubico} alt="GitHub Logo" />
-            <div className="join-button">
-              <a
-                className="join-button-link"
-                href="https://github.com/codeforgso"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Join Us
-              </a>
-              <div className="btn-arrow">
-                <i class="fas fa-arrow-right fa-2x"></i>
-              </div>
-            </div>
+            <OvalButton
+              text="Join Us"
+              to="https://github.com/codeforgso"
+              external="true"
+            />
           </div>
           <div className="column">
             <img src={meetupico} alt="Meetup Logo" />
-            <div className="join-button">
-              <a
-                className="join-button-link"
-                href="https://www.meetup.com/Code-for-Greensboro/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Join Us
-              </a>
-              <div className="btn-arrow">
-                <i class="fas fa-arrow-right fa-2x"></i>
-              </div>
-            </div>
+            <OvalButton
+              text="Join Us"
+              to="https://www.meetup.com/Code-for-Greensboro/"
+              external="true"
+            />
           </div>
         </div>
       </div>
@@ -159,18 +128,11 @@ const IndexPage = () => (
           counts to keep Code for Greensboro serving the Triad community.{" "}
         </p>
       </div>
-      <a
-        href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20Greensboro"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <div className="join-button">
-          <div class="join-button-link">Donate</div>
-          <div className="btn-arrow">
-            <i class="fas fa-arrow-right fa-2x"></i>
-          </div>
-        </div>
-      </a>
+      <OvalButton
+        text="Donate"
+        to="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20Greensboro"
+        external="true"
+      />
     </section>
   </Layout>
 )


### PR DESCRIPTION
Refactored the reused large oval 'call to action' button as a separate react component for easier updating and cleaner code on the homepage. It will take an internal gatsby type link or an external standard <a> type link based on the boolean prop 'external'. 