### PR TITLE
Update “Donate” page link

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -54,7 +54,7 @@ function Nav(props) {
           </Link>
 
           <a
-            href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20Greensboro"
+            href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20Greensboro&utm_source=CodeforGreensboroSite"
             className="navbar-item"
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ