### PR TITLE
Change Action trigger to push from pull-request

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,7 +1,7 @@
 name: Gatsby build and publish to gh-pages
 
 on:
-  pull_request:
+  push:
     branches: 
     - main
 


### PR DESCRIPTION
Change the trigger for the github action to fire on a pull to main as opposed to a pull-request being opened on the main branch.
